### PR TITLE
ci(agents): add golangci-lint with minimal-but-strict starter config

### DIFF
--- a/.github/workflows/agent-guardrails.yml
+++ b/.github/workflows/agent-guardrails.yml
@@ -48,6 +48,13 @@ jobs:
       - name: Install workspace deps
         run: pnpm install --frozen-lockfile
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: server
+          args: --timeout=5m
+
       - name: make verify
         run: make verify
 

--- a/server/.golangci.yml
+++ b/server/.golangci.yml
@@ -1,0 +1,34 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+  settings:
+    errcheck:
+      # Don't fail the build for fmt.Fprintf et al. Most of the noise here is
+      # writers we cannot meaningfully recover from.
+      check-type-assertions: false
+      check-blank: false
+      exclude-functions:
+        - (net/http.ResponseWriter).Write
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - fmt.Fprint
+        - encoding/json.NewEncoder.Encode
+
+issues:
+  exclusions:
+    rules:
+      - path: '_test\.go'
+        linters:
+          - errcheck
+          - unused


### PR DESCRIPTION
## Summary

- Add `server/.golangci.yml` (v2 schema) enabling 5 high-signal linters: `errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`
- Wire `golangci/golangci-lint-action@v6` into `agent-guardrails.yml` between "Install workspace deps" and "make verify"
- No server source files modified — STOP rule honored; stricter linter packs deferred to follow-up PRs

## Test plan

- [ ] CI `golangci-lint` step passes on this branch
- [ ] `make verify` still exits 0
- [ ] Only `server/.golangci.yml` and `.github/workflows/agent-guardrails.yml` are modified

Closes #9
Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)