### PR TITLE
chore(sandcastle): --file flag + ban AI co-author trailers

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -29,14 +29,30 @@
  */
 import { run, claudeCode } from "@ai-hero/sandcastle";
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-const task = process.argv.slice(2).join(" ").trim();
+// Args: either `--file <path>` (preferred for multi-line tasks containing
+// backticks/$/quotes — bypasses pnpm's sh -c re-parse of script args) or a
+// trailing positional task string.
+const argv = process.argv.slice(2);
+let task = "";
+const fileFlag = argv.indexOf("--file");
+if (fileFlag !== -1) {
+  const path = argv[fileFlag + 1];
+  if (!path) {
+    console.error("--file requires a path");
+    process.exit(1);
+  }
+  task = readFileSync(path, "utf8").trim();
+} else {
+  task = argv.join(" ").trim();
+}
 if (!task) {
   console.error(
     'usage: pnpm sandcastle "<task description>"\n' +
+      "       pnpm sandcastle --file <path-to-task.txt>\n" +
       "       (the task string is substituted into .sandcastle/prompt.md as {{TASK}})",
   );
   process.exit(1);

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -47,3 +47,14 @@ When the task is complete, commit your changes with a descriptive message and
 output `<promise>COMPLETE</promise>` on its own line to signal early
 termination. If you cannot finish the task, output a short explanation and
 the same `<promise>COMPLETE</promise>` marker so the run terminates cleanly.
+
+# Commit message hygiene (mandatory)
+
+- Do NOT add `Co-Authored-By: Claude <...>` (or any other AI / tool
+  attribution) to commit messages. The host's contributor authorship is the
+  only attribution that should appear.
+- Do NOT add `Generated-by:`, `Signed-off-by: Claude`, `Created-with:`, or any
+  similar trailer that identifies the assistant.
+- Do NOT include emojis, marketing language, or model identifiers
+  (`claude-opus-4-6`, `claude-3-5-sonnet`, etc.) in the commit subject or body.
+- The commit body should describe what changed and why — nothing more.


### PR DESCRIPTION
## Summary

Two small, independent improvements to the sandcastle dev-tool wiring landed in [`.sandcastle/`](.sandcastle):

1. **`--file <path>` flag for `pnpm sandcastle`** — multi-line task prompts containing backticks, `\$`, or quotes were being re-evaluated by pnpm's underlying `sh -c` when passed inline as script args, which corrupted every shell metacharacter in the task before it reached the agent. The new flag reads the task body from a file path and bypasses the re-parse entirely. Inline string usage still works for trivial tasks.
2. **Commit-message hygiene rules in `prompt.md`** — adds explicit instructions forbidding \`Co-Authored-By: Claude\` (and other AI/tool trailers, model identifiers, emojis, marketing language). Sandboxed runs were appending those trailers to every commit.

No product code touched. No new dependencies.

## Files

- [\`.sandcastle/main.mts\`](.sandcastle/main.mts) — adds the \`--file\` argument handling.
- [\`.sandcastle/README.md\`](.sandcastle/README.md) — unchanged in this PR; existing usage notes still hold.
- [\`.sandcastle/prompt.md\`](.sandcastle/prompt.md) — new \"Commit message hygiene\" section.

## Verification

Used in anger to drive #34 across 8 sandcastle runs without prompt corruption and with clean human-attributed commits. The two earlier-style commits with Claude trailers were rewritten via \`git rebase --exec\` before this PR went up.