### PR TITLE
refactor(handler): introduce ToolsRepo interface for db seam

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -33,6 +33,26 @@ golang-migrate v4.19.1 for schema migrations. All versions sourced from
 - Tests live next to the file as `*_test.go`, use `net/http/httptest`, and run
   from the `server/` directory: `go test ./...`.
 
+## Testing handlers that touch the DB
+
+To test handlers that query the database without requiring a live Postgres
+connection, use the **interface-injection** pattern:
+
+1. Define a per-handler interface next to the handler (e.g. `ToolsRepo`).
+2. Write an unexported `pgx*Repo` adapter that wraps `*pgxpool.Pool` and
+   implements the interface using the existing SQL.
+3. Change the handler to accept the interface instead of the pool.
+4. In tests, implement the interface with a hand-written mock struct — no
+   mocking libraries, no `pgx` imports in the test file.
+5. Wire the adapter in `cmd/api/main.go` via its constructor.
+
+See `internal/handler/tools.go` and `internal/handler/tools_test.go` for the
+canonical example.
+
+> This pattern is being rolled out to all handlers per
+> [issue #34](https://github.com/usagely/usagely/issues/34). `tools.go` is
+> Pillar 1; remaining handlers will follow in subsequent PRs.
+
 ## Verify before committing
 
 ```bash

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -51,7 +51,7 @@ func main() {
 		r.Get("/budgets", handler.Budgets(pool))
 		r.Get("/anomalies", handler.Anomalies(pool))
 		r.Get("/settings", handler.Settings)
-		r.Get("/tools", handler.Tools(pool))
+		r.Get("/tools", handler.Tools(handler.NewPgxToolsRepo(pool)))
 		r.Get("/models", handler.Models(pool))
 		r.Get("/people", handler.People(pool))
 		r.Get("/people/{email}", handler.Profile(pool))

--- a/server/internal/handler/tools.go
+++ b/server/internal/handler/tools.go
@@ -25,16 +25,62 @@ type ToolsResponse struct {
 	Tools []Tool `json:"tools"`
 }
 
-func Tools(pool *pgxpool.Pool) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-		defer cancel()
+type ToolsRepo interface {
+	ListTools(ctx context.Context, orgID string, category string) ([]Tool, error)
+}
 
+type pgxToolsRepo struct {
+	pool *pgxpool.Pool
+}
+
+func NewPgxToolsRepo(pool *pgxpool.Pool) ToolsRepo {
+	if pool == nil {
+		return nil
+	}
+	return &pgxToolsRepo{pool: pool}
+}
+
+func (r *pgxToolsRepo) ListTools(ctx context.Context, orgID string, category string) ([]Tool, error) {
+	query := `
+		SELECT id, name, vendor, category, status, seats, provisioning, spend_current, spend_prev
+		FROM tools
+		WHERE org_id = $1
+	`
+	args := []interface{}{orgID}
+
+	if category != "" && category != "All" {
+		query += ` AND category = $2`
+		args = append(args, category)
+	}
+
+	query += ` ORDER BY name ASC`
+
+	// tenancy:ok query is built above with WHERE org_id = $1
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tools []Tool
+	for rows.Next() {
+		var t Tool
+		if err := rows.Scan(&t.ID, &t.Name, &t.Vendor, &t.Category, &t.Status, &t.Seats, &t.Provisioning, &t.Spend, &t.Prev); err != nil {
+			return nil, err
+		}
+		tools = append(tools, t)
+	}
+
+	return tools, nil
+}
+
+func Tools(repo ToolsRepo) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		resp := &ToolsResponse{
 			Tools: []Tool{},
 		}
 
-		if pool == nil {
+		if repo == nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(resp)
@@ -49,35 +95,17 @@ func Tools(pool *pgxpool.Pool) http.HandlerFunc {
 
 		category := r.URL.Query().Get("category")
 
-		query := `
-			SELECT id, name, vendor, category, status, seats, provisioning, spend_current, spend_prev
-			FROM tools
-			WHERE org_id = $1
-		`
-		args := []interface{}{orgID}
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
 
-		if category != "" && category != "All" {
-			query += ` AND category = $2`
-			args = append(args, category)
-		}
-
-		query += ` ORDER BY name ASC`
-
-		// tenancy:ok query is built above with WHERE org_id = $1
-		rows, err := pool.Query(ctx, query, args...)
+		tools, err := repo.ListTools(ctx, orgID, category)
 		if err != nil {
 			http.Error(w, "failed to fetch tools", http.StatusInternalServerError)
 			return
 		}
-		defer rows.Close()
 
-		for rows.Next() {
-			var t Tool
-			if err := rows.Scan(&t.ID, &t.Name, &t.Vendor, &t.Category, &t.Status, &t.Seats, &t.Provisioning, &t.Spend, &t.Prev); err != nil {
-				http.Error(w, "failed to scan tool", http.StatusInternalServerError)
-				return
-			}
-			resp.Tools = append(resp.Tools, t)
+		if tools != nil {
+			resp.Tools = tools
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/server/internal/handler/tools_test.go
+++ b/server/internal/handler/tools_test.go
@@ -1,0 +1,167 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type mockToolsRepo struct {
+	tools       []Tool
+	err         error
+	gotOrgID    string
+	gotCategory string
+}
+
+func (m *mockToolsRepo) ListTools(_ context.Context, orgID string, category string) ([]Tool, error) {
+	m.gotOrgID = orgID
+	m.gotCategory = category
+	return m.tools, m.err
+}
+
+func TestToolsHappyPath(t *testing.T) {
+	seats := 10
+	mock := &mockToolsRepo{
+		tools: []Tool{
+			{ID: "1", Name: "ChatGPT", Vendor: "OpenAI", Category: "LLM", Status: "active", Seats: &seats, Provisioning: "manual", Spend: 100.0, Prev: 90.0},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/tools", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Tools(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ToolsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(resp.Tools))
+	}
+	if resp.Tools[0].Name != "ChatGPT" {
+		t.Errorf("expected name ChatGPT, got %s", resp.Tools[0].Name)
+	}
+	if resp.Tools[0].ID != "1" {
+		t.Errorf("expected ID 1, got %s", resp.Tools[0].ID)
+	}
+}
+
+func TestToolsEmptyResult(t *testing.T) {
+	mock := &mockToolsRepo{
+		tools: []Tool{},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/tools", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Tools(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ToolsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Tools == nil {
+		t.Fatal("expected non-nil tools array, got null")
+	}
+	if len(resp.Tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(resp.Tools))
+	}
+}
+
+func TestToolsRepoError(t *testing.T) {
+	mock := &mockToolsRepo{
+		err: errors.New("connection refused"),
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/tools", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Tools(mock)(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "failed to fetch tools") {
+		t.Errorf("expected body to contain 'failed to fetch tools', got %q", body)
+	}
+}
+
+func TestToolsUnauthorized(t *testing.T) {
+	mock := &mockToolsRepo{}
+
+	req := httptest.NewRequest("GET", "/api/v1/tools", nil)
+	w := httptest.NewRecorder()
+
+	Tools(mock)(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestToolsNilRepo(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/tools", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Tools(nil)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ToolsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Tools == nil {
+		t.Fatal("expected non-nil tools array, got null")
+	}
+	if len(resp.Tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(resp.Tools))
+	}
+}
+
+func TestToolsCategoryForwarded(t *testing.T) {
+	mock := &mockToolsRepo{
+		tools: []Tool{},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/tools?category=LLM", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Tools(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	if mock.gotOrgID != "test-org" {
+		t.Errorf("expected orgID 'test-org', got %q", mock.gotOrgID)
+	}
+	if mock.gotCategory != "LLM" {
+		t.Errorf("expected category 'LLM', got %q", mock.gotCategory)
+	}
+}


### PR DESCRIPTION
## Summary

First PR in the [#34](https://github.com/usagely/usagely/issues/34) sequence. Establishes the **interface-injection** pattern for handler-level DB seams using \`Tools\` as the canonical example. Follow-up PRs in the issue's suggested PR sequence apply the same pattern to the remaining handlers.

## What changed

- [\`server/internal/handler/tools.go\`](server/internal/handler/tools.go) — new \`ToolsRepo\` interface, unexported \`pgxToolsRepo\` adapter, \`NewPgxToolsRepo()\` constructor. Handler now accepts the interface. Tenancy comment preserved.
- [\`server/internal/handler/tools_test.go\`](server/internal/handler/tools_test.go) — 6 tests, hand-written \`mockToolsRepo\`, no \`pgx\` imports. Covers happy path, empty, repo error, unauthorized, nil repo, category-forwarded.
- [\`server/cmd/api/main.go\`](server/cmd/api/main.go) — one-line wiring: \`handler.Tools(handler.NewPgxToolsRepo(pool))\`.
- [\`server/AGENTS.md\`](server/AGENTS.md) — new \"Testing handlers that touch the DB\" section documenting the pattern.

## Verification

\`\`\`
cd server && go vet ./...    # exit 0
cd server && go test ./...   # all pass, tenancy lint green
cd server && go build ./...  # exit 0
\`\`\`

The \`Tools\` handler function reaches **100%** coverage. The \`pgxToolsRepo\` adapter sits at 0% by design — driving it would require a live Postgres, which is an explicit non-goal of #34.

## Closes (partial)

Pillar 1 of #34. Subsequent PRs in the [suggested sequence](https://github.com/usagely/usagely/issues/34) close the remaining checkboxes.