### PR TITLE
test(middleware): cover requestid, recovery, logging, cors, edition

### DIFF
--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -145,6 +145,35 @@ func TestAuthMiddleware(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_DevMode(t *testing.T) {
+	am := NewAuthMiddleware("skip")
+
+	var gotUserID, gotEmail, gotOrgID string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserID, _ = r.Context().Value(ContextKeyUserID).(string)
+		gotEmail, _ = r.Context().Value(ContextKeyUserEmail).(string)
+		gotOrgID, _ = r.Context().Value("org_id").(string)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	am.Handler(next).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if gotUserID != "dev-user" {
+		t.Errorf("userID = %q, want %q", gotUserID, "dev-user")
+	}
+	if gotEmail != "dev@usagely.local" {
+		t.Errorf("email = %q, want %q", gotEmail, "dev@usagely.local")
+	}
+	if gotOrgID != "00000000-0000-0000-0000-000000000001" {
+		t.Errorf("org_id = %q, want %q", gotOrgID, "00000000-0000-0000-0000-000000000001")
+	}
+}
+
 func TestEditionGate(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/server/internal/middleware/cors_test.go
+++ b/server/internal/middleware/cors_test.go
@@ -1,0 +1,100 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCORS(t *testing.T) {
+	const allowedOrigin = "https://app.usagely.io"
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := CORS(allowedOrigin)(next)
+
+	tests := []struct {
+		name    string
+		method  string
+		origin  string
+		headers map[string]string
+		check   func(t *testing.T, resp *httptest.ResponseRecorder)
+	}{
+		{
+			name:   "preflight from allowed origin",
+			method: http.MethodOptions,
+			origin: allowedOrigin,
+			headers: map[string]string{
+				"Access-Control-Request-Method":  "POST",
+				"Access-Control-Request-Headers": "Content-Type, Authorization, Cookie",
+			},
+			check: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				t.Helper()
+				h := resp.Header()
+				if got := h.Get("Access-Control-Allow-Origin"); got != allowedOrigin {
+					t.Errorf("Allow-Origin = %q, want %q", got, allowedOrigin)
+				}
+				if got := h.Get("Access-Control-Allow-Methods"); got == "" {
+					t.Error("Allow-Methods is empty")
+				}
+				hdrs := h.Get("Access-Control-Allow-Headers")
+				for _, hdr := range []string{"Content-Type", "Authorization", "Cookie"} {
+					if !strings.Contains(strings.ToLower(hdrs), strings.ToLower(hdr)) {
+						t.Errorf("Allow-Headers %q missing %s", hdrs, hdr)
+					}
+				}
+				if got := h.Get("Access-Control-Allow-Credentials"); got != "true" {
+					t.Errorf("Allow-Credentials = %q, want true", got)
+				}
+				if got := h.Get("Access-Control-Max-Age"); got != "300" {
+					t.Errorf("Max-Age = %q, want 300", got)
+				}
+			},
+		},
+		{
+			name:   "non-allowed origin gets no CORS headers",
+			method: http.MethodOptions,
+			origin: "https://evil.example.com",
+			headers: map[string]string{
+				"Access-Control-Request-Method": "GET",
+			},
+			check: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				t.Helper()
+				if got := resp.Header().Get("Access-Control-Allow-Origin"); got != "" {
+					t.Errorf("Allow-Origin = %q, want empty for non-allowed origin", got)
+				}
+			},
+		},
+		{
+			name:   "simple GET from allowed origin",
+			method: http.MethodGet,
+			origin: allowedOrigin,
+			check: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				t.Helper()
+				if got := resp.Header().Get("Access-Control-Allow-Origin"); got != allowedOrigin {
+					t.Errorf("Allow-Origin = %q, want %q", got, allowedOrigin)
+				}
+				exposed := resp.Header().Get("Access-Control-Expose-Headers")
+				if !strings.Contains(exposed, "Content-Length") {
+					t.Errorf("Expose-Headers %q missing Content-Length", exposed)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/api/v1/test", nil)
+			req.Header.Set("Origin", tc.origin)
+			for k, v := range tc.headers {
+				req.Header.Set(k, v)
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			tc.check(t, w)
+		})
+	}
+}

--- a/server/internal/middleware/edition_test.go
+++ b/server/internal/middleware/edition_test.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEditionGate_HeaderOverride(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name          string
+		serverEdition string
+		xEdition      string
+		path          string
+		wantStatus    int
+	}{
+		{
+			name:          "X-Edition ee overrides oss server on EE route",
+			serverEdition: "oss",
+			xEdition:      "ee",
+			path:          "/api/v1/recommendations",
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:          "oss server blocks shadow route",
+			serverEdition: "oss",
+			path:          "/api/v1/shadow",
+			wantStatus:    http.StatusForbidden,
+		},
+		{
+			name:          "ee server allows recommendations without header",
+			serverEdition: "ee",
+			path:          "/api/v1/recommendations",
+			wantStatus:    http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gate := EditionGate(tc.serverEdition)
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if tc.xEdition != "" {
+				req.Header.Set("X-Edition", tc.xEdition)
+			}
+			w := httptest.NewRecorder()
+			gate(next).ServeHTTP(w, req)
+			if w.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tc.wantStatus)
+			}
+			if tc.wantStatus == http.StatusForbidden {
+				if got := w.Header().Get("Content-Type"); got != "application/json" {
+					t.Errorf("Content-Type = %q, want application/json", got)
+				}
+				var body map[string]string
+				if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+					t.Fatalf("decode body: %v", err)
+				}
+				if body["error"] != "enterprise edition required" {
+					t.Errorf("error = %q, want %q", body["error"], "enterprise edition required")
+				}
+			}
+		})
+	}
+}
+
+func TestIsEERoute(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/api/v1/recommendations", true},
+		{"/api/v1/recommendations/123", true},
+		{"/api/v1/shadow", true},
+		{"/api/v1/shadow/config", true},
+		{"/api/v1/approvals", true},
+		{"/api/v1/forecast", true},
+		{"/api/v1/dashboard", false},
+		{"/api/v1/usage", false},
+		{"/", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := isEERoute(tc.path); got != tc.want {
+				t.Errorf("isEERoute(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/middleware/logging_test.go
+++ b/server/internal/middleware/logging_test.go
@@ -1,0 +1,92 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestLogger(t *testing.T) {
+	t.Run("logs method path status duration and request_id", func(t *testing.T) {
+		var buf bytes.Buffer
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+		t.Cleanup(func() {
+			slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+		})
+
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		})
+
+		handler := RequestID(Logger(inner))
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/test", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		var entry map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+			t.Fatalf("unmarshal log: %v (raw: %s)", err, buf.String())
+		}
+		if got := entry["method"]; got != "POST" {
+			t.Errorf("method = %v, want POST", got)
+		}
+		if got := entry["path"]; got != "/api/v1/test" {
+			t.Errorf("path = %v, want /api/v1/test", got)
+		}
+		if got, ok := entry["status"].(float64); !ok || int(got) != http.StatusTeapot {
+			t.Errorf("status = %v, want %d", entry["status"], http.StatusTeapot)
+		}
+		if _, ok := entry["duration"]; !ok {
+			t.Error("duration field missing from log")
+		}
+		if got, ok := entry["request_id"].(string); !ok || got == "" {
+			t.Error("request_id missing or empty in log")
+		}
+	})
+
+	t.Run("responseWriter records WriteHeader status", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		rw := &responseWriter{ResponseWriter: rec, statusCode: http.StatusOK}
+		rw.WriteHeader(http.StatusNotFound)
+
+		if rw.statusCode != http.StatusNotFound {
+			t.Errorf("statusCode = %d, want %d", rw.statusCode, http.StatusNotFound)
+		}
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("underlying recorder code = %d, want %d", rec.Code, http.StatusNotFound)
+		}
+	})
+
+	t.Run("defaults to 200 when Write called without WriteHeader", func(t *testing.T) {
+		var buf bytes.Buffer
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+		t.Cleanup(func() {
+			slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+		})
+
+		inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("no explicit WriteHeader"))
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx := context.WithValue(req.Context(), RequestIDKey, "test-id")
+		req = req.WithContext(ctx)
+
+		w := httptest.NewRecorder()
+		Logger(inner).ServeHTTP(w, req)
+
+		var entry map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+			t.Fatalf("unmarshal log: %v (raw: %s)", err, buf.String())
+		}
+		if got, ok := entry["status"].(float64); !ok || int(got) != http.StatusOK {
+			t.Errorf("status = %v, want %d", entry["status"], http.StatusOK)
+		}
+	})
+}

--- a/server/internal/middleware/recovery_test.go
+++ b/server/internal/middleware/recovery_test.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestRecovery(t *testing.T) {
+	t.Run("catches panic and returns 500 JSON", func(t *testing.T) {
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic("boom")
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/explode", nil)
+		w := httptest.NewRecorder()
+		Recovery(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+		}
+		want := `{"error":"internal server error"}`
+		if got := w.Body.String(); got != want {
+			t.Errorf("body = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("passes through non-panicking handler", func(t *testing.T) {
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = w.Write([]byte("ok"))
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/safe", nil)
+		w := httptest.NewRecorder()
+		Recovery(next).ServeHTTP(w, req)
+
+		if w.Code != http.StatusTeapot {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusTeapot)
+		}
+		if got := w.Body.String(); got != "ok" {
+			t.Errorf("body = %q, want %q", got, "ok")
+		}
+	})
+
+	t.Run("logs panic value and request path", func(t *testing.T) {
+		var buf bytes.Buffer
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+		t.Cleanup(func() {
+			slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+		})
+
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			panic("boom")
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/explode", nil)
+		w := httptest.NewRecorder()
+		Recovery(next).ServeHTTP(w, req)
+
+		var entry map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+			t.Fatalf("unmarshal log: %v (raw: %s)", err, buf.String())
+		}
+		if got, _ := entry["error"].(string); got != "boom" {
+			t.Errorf("logged error = %q, want %q", got, "boom")
+		}
+		if got, _ := entry["path"].(string); got != "/explode" {
+			t.Errorf("logged path = %q, want %q", got, "/explode")
+		}
+	})
+}

--- a/server/internal/middleware/requestid_test.go
+++ b/server/internal/middleware/requestid_test.go
@@ -1,0 +1,72 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+)
+
+var uuidV4Re = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestRequestID(t *testing.T) {
+	t.Run("generates UUIDv4 when no header present", func(t *testing.T) {
+		var ctxID string
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctxID = r.Context().Value(RequestIDKey).(string)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		RequestID(next).ServeHTTP(w, req)
+
+		respID := w.Header().Get(RequestIDKey)
+		if respID == "" {
+			t.Fatal("response header request-id is empty")
+		}
+		if !uuidV4Re.MatchString(respID) {
+			t.Errorf("response header %q does not match UUIDv4 pattern", respID)
+		}
+		if ctxID != respID {
+			t.Errorf("context id %q != response header id %q", ctxID, respID)
+		}
+	})
+
+	t.Run("propagates existing header without overwrite", func(t *testing.T) {
+		const incoming = "my-custom-request-id"
+		var ctxID string
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctxID = r.Context().Value(RequestIDKey).(string)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set(RequestIDKey, incoming)
+		w := httptest.NewRecorder()
+		RequestID(next).ServeHTTP(w, req)
+
+		if got := w.Header().Get(RequestIDKey); got != incoming {
+			t.Errorf("response header = %q, want %q", got, incoming)
+		}
+		if ctxID != incoming {
+			t.Errorf("context id = %q, want %q", ctxID, incoming)
+		}
+	})
+
+	t.Run("downstream handler reads id from context", func(t *testing.T) {
+		var ctxVal any
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctxVal = r.Context().Value(RequestIDKey)
+		})
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+		RequestID(next).ServeHTTP(w, req)
+
+		id, ok := ctxVal.(string)
+		if !ok || id == "" {
+			t.Fatal("downstream could not read request id from context")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Pillar 3 of [#34](https://github.com/usagely/usagely/issues/34). Adds tests for every middleware that lacked one and extends \`auth_test.go\` with one missing case. **No middleware source files were modified** — pure test addition.

> Stacked on top of #37 (Tools seam). Review there first.

## New test files

- [\`requestid_test.go\`](server/internal/middleware/requestid_test.go) — UUIDv4 generation when no header present, propagation when one is, context readback.
- [\`recovery_test.go\`](server/internal/middleware/recovery_test.go) — panic → 500 + JSON body, passthrough on non-panic, slog assertion via captured handler.
- [\`logging_test.go\`](server/internal/middleware/logging_test.go) — slog field assertions, \`responseWriter\` status recording, default 200 when handler omits \`WriteHeader\`.
- [\`cors_test.go\`](server/internal/middleware/cors_test.go) — preflight headers, non-allowed origin drop, simple GET echo.
- [\`edition_test.go\`](server/internal/middleware/edition_test.go) — \`X-Edition\` header override, \`isEERoute\` direct tests for all four prefixes plus negative.

## auth_test.go

Added one missing case: dev-mode (\`jwksURL=\"skip\"\`).

## Coverage

\`\`\`
cd server && go test ./internal/middleware/... -cover
ok      github.com/usagely/usagely/internal/middleware  ...  coverage: 94.9%
\`\`\`

Tests pass with \`-race\`. Full backend suite green.

## Closes

Pillar 3 of #34.