### PR TITLE
test(handler): cover anomalies, forecast, teams

### DIFF
--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -47,9 +47,9 @@ func main() {
 		r.Use(authMiddleware.Handler)
 		r.Use(middleware.EditionGate(cfg.Edition))
 		r.Get("/dashboard", handler.Dashboard(pool))
-		r.Get("/teams", handler.Teams(pool))
+		r.Get("/teams", handler.Teams(handler.NewPgxTeamsRepo(pool)))
 		r.Get("/budgets", handler.Budgets(handler.NewPgxBudgetsRepo(pool)))
-		r.Get("/anomalies", handler.Anomalies(pool))
+		r.Get("/anomalies", handler.Anomalies(handler.NewPgxAnomaliesRepo(pool)))
 		r.Get("/settings", handler.Settings(handler.NewPgxSettingsRepo(pool)))
 		r.Get("/tools", handler.Tools(handler.NewPgxToolsRepo(pool)))
 		r.Get("/models", handler.Models(handler.NewPgxModelsRepo(pool)))
@@ -58,7 +58,7 @@ func main() {
 		r.Get("/recommendations", handler.Recommendations(handler.NewPgxRecommendationsRepo(pool)))
 		r.Get("/shadow", handler.Shadow(handler.NewPgxShadowRepo(pool)))
 		r.Get("/approvals", handler.Approvals(handler.NewPgxApprovalsRepo(pool)))
-		r.Get("/forecast", handler.Forecast(pool))
+		r.Get("/forecast", handler.Forecast(handler.NewPgxForecastRepo(pool)))
 	})
 
 	srv := &http.Server{

--- a/server/internal/handler/anomalies.go
+++ b/server/internal/handler/anomalies.go
@@ -23,8 +23,50 @@ type AnomaliesResponse struct {
 	Anomalies []AnomalyItem `json:"anomalies"`
 }
 
+type AnomaliesRepo interface {
+	ListAnomalies(ctx context.Context, orgID string) ([]AnomalyItem, error)
+}
+
+type pgxAnomaliesRepo struct {
+	pool *pgxpool.Pool
+}
+
+func NewPgxAnomaliesRepo(pool *pgxpool.Pool) AnomaliesRepo {
+	if pool == nil {
+		return nil
+	}
+	return &pgxAnomaliesRepo{pool: pool}
+}
+
+func (r *pgxAnomaliesRepo) ListAnomalies(ctx context.Context, orgID string) ([]AnomalyItem, error) {
+	// tenancy:ok query filters by org_id = $1
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, title, body, severity, team_name, owner_name, detected_at
+		FROM anomalies
+		WHERE org_id = $1
+		ORDER BY detected_at DESC
+	`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var anomalies []AnomalyItem
+	for rows.Next() {
+		var a AnomalyItem
+		var detectedAt time.Time
+		if err := rows.Scan(&a.ID, &a.Title, &a.Body, &a.Severity, &a.TeamName, &a.OwnerName, &detectedAt); err != nil {
+			return nil, err
+		}
+		a.DetectedAt = detectedAt.Format(time.RFC3339)
+		anomalies = append(anomalies, a)
+	}
+
+	return anomalies, nil
+}
+
 // Anomalies returns a handler that fetches all anomalies for the org
-func Anomalies(pool *pgxpool.Pool) http.HandlerFunc {
+func Anomalies(repo AnomaliesRepo) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
@@ -40,8 +82,8 @@ func Anomalies(pool *pgxpool.Pool) http.HandlerFunc {
 			Anomalies: []AnomalyItem{},
 		}
 
-		// If no pool, return empty response
-		if pool == nil {
+		// If no repo, return empty response
+		if repo == nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(resp)
@@ -49,27 +91,14 @@ func Anomalies(pool *pgxpool.Pool) http.HandlerFunc {
 		}
 
 		// Fetch anomalies for org, ordered by detected_at DESC
-		rows, err := pool.Query(ctx, `
-			SELECT id, title, body, severity, team_name, owner_name, detected_at
-			FROM anomalies
-			WHERE org_id = $1
-			ORDER BY detected_at DESC
-		`, orgID)
+		anomalies, err := repo.ListAnomalies(ctx, orgID)
 		if err != nil {
 			http.Error(w, "failed to fetch anomalies", http.StatusInternalServerError)
 			return
 		}
-		defer rows.Close()
 
-		for rows.Next() {
-			var a AnomalyItem
-			var detectedAt time.Time
-			if err := rows.Scan(&a.ID, &a.Title, &a.Body, &a.Severity, &a.TeamName, &a.OwnerName, &detectedAt); err != nil {
-				http.Error(w, "failed to scan anomaly", http.StatusInternalServerError)
-				return
-			}
-			a.DetectedAt = detectedAt.Format(time.RFC3339)
-			resp.Anomalies = append(resp.Anomalies, a)
+		if anomalies != nil {
+			resp.Anomalies = anomalies
 		}
 
 		// Add hardcoded extended anomalies if DB is empty or has fewer than expected

--- a/server/internal/handler/anomalies_test.go
+++ b/server/internal/handler/anomalies_test.go
@@ -1,0 +1,177 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type mockAnomaliesRepo struct {
+	anomalies []AnomalyItem
+	err       error
+	gotOrgID  string
+}
+
+func (m *mockAnomaliesRepo) ListAnomalies(_ context.Context, orgID string) ([]AnomalyItem, error) {
+	m.gotOrgID = orgID
+	return m.anomalies, m.err
+}
+
+func TestAnomaliesHappyPath(t *testing.T) {
+	mock := &mockAnomaliesRepo{
+		anomalies: []AnomalyItem{
+			{ID: "a1", Title: "GPU spike", Body: "Unexpected GPU usage", Severity: "critical", TeamName: "ML", OwnerName: "Alice", DetectedAt: "2025-01-01T00:00:00Z"},
+			{ID: "a2", Title: "Token surge", Body: "Token usage up 40%", Severity: "warn", TeamName: "Eng", OwnerName: "Bob", DetectedAt: "2025-01-02T00:00:00Z"},
+			{ID: "a3", Title: "Idle seats", Body: "10 seats unused", Severity: "info", TeamName: "Sales", OwnerName: "Carol", DetectedAt: "2025-01-03T00:00:00Z"},
+			{ID: "a4", Title: "API errors", Body: "Error rate up", Severity: "critical", TeamName: "Platform", OwnerName: "Dave", DetectedAt: "2025-01-04T00:00:00Z"},
+			{ID: "a5", Title: "Cost anomaly", Body: "Spend doubled", Severity: "warn", TeamName: "Data", OwnerName: "Eve", DetectedAt: "2025-01-05T00:00:00Z"},
+			{ID: "a6", Title: "New model cost", Body: "GPT-5 costs high", Severity: "info", TeamName: "Research", OwnerName: "Frank", DetectedAt: "2025-01-06T00:00:00Z"},
+			{ID: "a7", Title: "Batch job spike", Body: "Batch processing up", Severity: "warn", TeamName: "Ops", OwnerName: "Grace", DetectedAt: "2025-01-07T00:00:00Z"},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/anomalies", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Anomalies(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp AnomaliesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.Anomalies) != 7 {
+		t.Fatalf("expected 7 anomalies (no extension), got %d", len(resp.Anomalies))
+	}
+	if resp.Anomalies[0].Title != "GPU spike" {
+		t.Errorf("expected title 'GPU spike', got %s", resp.Anomalies[0].Title)
+	}
+	if resp.Anomalies[0].ID != "a1" {
+		t.Errorf("expected ID a1, got %s", resp.Anomalies[0].ID)
+	}
+}
+
+func TestAnomaliesExtendedFallback(t *testing.T) {
+	mock := &mockAnomaliesRepo{
+		anomalies: []AnomalyItem{
+			{ID: "a1", Title: "GPU spike", Body: "Unexpected GPU usage", Severity: "critical", TeamName: "ML", OwnerName: "Alice", DetectedAt: "2025-01-01T00:00:00Z"},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/anomalies", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Anomalies(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp AnomaliesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.Anomalies) != 4 {
+		t.Fatalf("expected 4 anomalies (1 db + 3 extended), got %d", len(resp.Anomalies))
+	}
+	if resp.Anomalies[1].ID != "a5" {
+		t.Errorf("expected extended anomaly ID a5, got %s", resp.Anomalies[1].ID)
+	}
+}
+
+func TestAnomaliesEmptyResult(t *testing.T) {
+	mock := &mockAnomaliesRepo{
+		anomalies: []AnomalyItem{},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/anomalies", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Anomalies(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp AnomaliesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Anomalies == nil {
+		t.Fatal("expected non-nil anomalies array, got null")
+	}
+	if len(resp.Anomalies) != 3 {
+		t.Fatalf("expected 3 extended anomalies for empty DB, got %d", len(resp.Anomalies))
+	}
+}
+
+func TestAnomaliesRepoError(t *testing.T) {
+	mock := &mockAnomaliesRepo{
+		err: errors.New("connection refused"),
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/anomalies", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Anomalies(mock)(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "failed to fetch anomalies") {
+		t.Errorf("expected body to contain 'failed to fetch anomalies', got %q", body)
+	}
+}
+
+func TestAnomaliesUnauthorized(t *testing.T) {
+	mock := &mockAnomaliesRepo{}
+
+	req := httptest.NewRequest("GET", "/api/v1/anomalies", nil)
+	w := httptest.NewRecorder()
+
+	Anomalies(mock)(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestAnomaliesNilRepo(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/anomalies", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Anomalies(nil)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp AnomaliesResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Anomalies == nil {
+		t.Fatal("expected non-nil anomalies array, got null")
+	}
+	if len(resp.Anomalies) != 0 {
+		t.Errorf("expected 0 anomalies, got %d", len(resp.Anomalies))
+	}
+}

--- a/server/internal/handler/forecast.go
+++ b/server/internal/handler/forecast.go
@@ -30,7 +30,47 @@ type ForecastResponse struct {
 	Scenarios       []ForecastScenario `json:"scenarios"`
 }
 
-func Forecast(pool *pgxpool.Pool) http.HandlerFunc {
+type ForecastRepo interface {
+	ListDailySpend(ctx context.Context, orgID string) ([]DailySpend, error)
+}
+
+type pgxForecastRepo struct {
+	pool *pgxpool.Pool
+}
+
+func NewPgxForecastRepo(pool *pgxpool.Pool) ForecastRepo {
+	if pool == nil {
+		return nil
+	}
+	return &pgxForecastRepo{pool: pool}
+}
+
+func (r *pgxForecastRepo) ListDailySpend(ctx context.Context, orgID string) ([]DailySpend, error) {
+	// tenancy:ok query filters by org_id = $1
+	rows, err := r.pool.Query(ctx, `
+		SELECT date, total_value FROM usage_daily
+		WHERE org_id = $1
+		ORDER BY date ASC
+		LIMIT 60
+	`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var hist []DailySpend
+	for rows.Next() {
+		var ds DailySpend
+		if err := rows.Scan(&ds.Date, &ds.Value); err != nil {
+			return nil, err
+		}
+		hist = append(hist, ds)
+	}
+
+	return hist, nil
+}
+
+func Forecast(repo ForecastRepo) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
@@ -48,34 +88,21 @@ func Forecast(pool *pgxpool.Pool) http.HandlerFunc {
 			Scenarios:       []ForecastScenario{},
 		}
 
-		if pool == nil {
+		if repo == nil {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
-		rows, err := pool.Query(ctx, `
-			SELECT date, total_value FROM usage_daily
-			WHERE org_id = $1
-			ORDER BY date ASC
-			LIMIT 60
-		`, orgID)
+		hist, err := repo.ListDailySpend(ctx, orgID)
 		if err != nil {
 			http.Error(w, "failed to fetch daily spend", http.StatusInternalServerError)
 			return
 		}
-		defer rows.Close()
 
-		var hist []DailySpend
-		for rows.Next() {
-			var ds DailySpend
-			if err := rows.Scan(&ds.Date, &ds.Value); err != nil {
-				http.Error(w, "failed to scan daily spend", http.StatusInternalServerError)
-				return
-			}
-			hist = append(hist, ds)
+		if hist != nil {
+			resp.HistoricalSpend = hist
 		}
-		resp.HistoricalSpend = hist
 
 		if len(hist) == 0 {
 			w.Header().Set("Content-Type", "application/json")

--- a/server/internal/handler/forecast_test.go
+++ b/server/internal/handler/forecast_test.go
@@ -1,0 +1,158 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type mockForecastRepo struct {
+	dailySpend []DailySpend
+	err        error
+	gotOrgID   string
+}
+
+func (m *mockForecastRepo) ListDailySpend(_ context.Context, orgID string) ([]DailySpend, error) {
+	m.gotOrgID = orgID
+	return m.dailySpend, m.err
+}
+
+func TestForecastHappyPath(t *testing.T) {
+	mock := &mockForecastRepo{
+		dailySpend: []DailySpend{
+			{Date: "2025-01-01", Value: 100.0},
+			{Date: "2025-01-02", Value: 105.0},
+			{Date: "2025-01-03", Value: 110.0},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/forecast", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Forecast(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ForecastResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.HistoricalSpend) != 3 {
+		t.Fatalf("expected 3 historical spend entries, got %d", len(resp.HistoricalSpend))
+	}
+	if len(resp.ProjectedSpend) != 30 {
+		t.Fatalf("expected 30 projected spend entries, got %d", len(resp.ProjectedSpend))
+	}
+	if len(resp.Drivers) != 5 {
+		t.Fatalf("expected 5 drivers, got %d", len(resp.Drivers))
+	}
+	if len(resp.Scenarios) != 4 {
+		t.Fatalf("expected 4 scenarios, got %d", len(resp.Scenarios))
+	}
+	if resp.HistoricalSpend[0].Date != "2025-01-01" {
+		t.Errorf("expected first date 2025-01-01, got %s", resp.HistoricalSpend[0].Date)
+	}
+}
+
+func TestForecastEmptyResult(t *testing.T) {
+	mock := &mockForecastRepo{
+		dailySpend: []DailySpend{},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/forecast", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Forecast(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ForecastResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.HistoricalSpend == nil {
+		t.Fatal("expected non-nil historical_spend array, got null")
+	}
+	if len(resp.HistoricalSpend) != 0 {
+		t.Errorf("expected 0 historical spend entries, got %d", len(resp.HistoricalSpend))
+	}
+	if len(resp.ProjectedSpend) != 0 {
+		t.Errorf("expected 0 projected spend entries, got %d", len(resp.ProjectedSpend))
+	}
+	if len(resp.Drivers) != 0 {
+		t.Errorf("expected 0 drivers, got %d", len(resp.Drivers))
+	}
+	if len(resp.Scenarios) != 0 {
+		t.Errorf("expected 0 scenarios, got %d", len(resp.Scenarios))
+	}
+}
+
+func TestForecastRepoError(t *testing.T) {
+	mock := &mockForecastRepo{
+		err: errors.New("connection refused"),
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/forecast", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Forecast(mock)(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "failed to fetch daily spend") {
+		t.Errorf("expected body to contain 'failed to fetch daily spend', got %q", body)
+	}
+}
+
+func TestForecastUnauthorized(t *testing.T) {
+	mock := &mockForecastRepo{}
+
+	req := httptest.NewRequest("GET", "/api/v1/forecast", nil)
+	w := httptest.NewRecorder()
+
+	Forecast(mock)(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestForecastNilRepo(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/forecast", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Forecast(nil)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ForecastResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.HistoricalSpend == nil {
+		t.Fatal("expected non-nil historical_spend array, got null")
+	}
+	if len(resp.HistoricalSpend) != 0 {
+		t.Errorf("expected 0 historical spend entries, got %d", len(resp.HistoricalSpend))
+	}
+}

--- a/server/internal/handler/teams.go
+++ b/server/internal/handler/teams.go
@@ -30,14 +30,63 @@ type CostVsOutput struct {
 	Color   string  `json:"color"`
 }
 
+type TeamRow struct {
+	ID      string
+	Name    string
+	Color   string
+	Members int
+}
+
 type TeamsResponse struct {
 	Teams        []Team         `json:"teams"`
 	Heatmap      [][]float64    `json:"heatmap"`
 	CostVsOutput []CostVsOutput `json:"cost_vs_output"`
 }
 
+type TeamsRepo interface {
+	ListTeams(ctx context.Context, orgID string) ([]TeamRow, error)
+}
+
+type pgxTeamsRepo struct {
+	pool *pgxpool.Pool
+}
+
+func NewPgxTeamsRepo(pool *pgxpool.Pool) TeamsRepo {
+	if pool == nil {
+		return nil
+	}
+	return &pgxTeamsRepo{pool: pool}
+}
+
+func (r *pgxTeamsRepo) ListTeams(ctx context.Context, orgID string) ([]TeamRow, error) {
+	// tenancy:ok query filters by org_id = $1
+	teamRows, err := r.pool.Query(ctx, `
+		SELECT t.id, t.name, t.color, COUNT(u.id) as members
+		FROM teams t
+		LEFT JOIN users u ON u.team_id = t.id
+		WHERE t.org_id = $1
+		GROUP BY t.id, t.name, t.color
+		ORDER BY t.created_at ASC
+	`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer teamRows.Close()
+
+	var rows []TeamRow
+	for teamRows.Next() {
+		var tr TeamRow
+		if err := teamRows.Scan(&tr.ID, &tr.Name, &tr.Color, &tr.Members); err != nil {
+			return nil, err
+		}
+		rows = append(rows, tr)
+	}
+
+	return rows, nil
+}
+
 // Teams returns a handler that fetches all teams data
-func Teams(pool *pgxpool.Pool) http.HandlerFunc {
+func Teams(repo TeamsRepo) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
@@ -48,8 +97,8 @@ func Teams(pool *pgxpool.Pool) http.HandlerFunc {
 			CostVsOutput: []CostVsOutput{},
 		}
 
-		// If no pool, return empty response
-		if pool == nil {
+		// If no repo, return empty response
+		if repo == nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(resp)
@@ -71,26 +120,18 @@ func Teams(pool *pgxpool.Pool) http.HandlerFunc {
 		deltas := []float64{0.18, 0.05, 0.41, 0.12, -0.08, 0.02, 0.0, 0.09}
 
 		// Fetch teams with member count
-		teamRows, err := pool.Query(ctx, `
-			SELECT t.id, t.name, t.color, COUNT(u.id) as members
-			FROM teams t
-			LEFT JOIN users u ON u.team_id = t.id
-			WHERE t.org_id = $1
-			GROUP BY t.id, t.name, t.color
-			ORDER BY t.created_at ASC
-		`, orgID)
+		teamRows, err := repo.ListTeams(ctx, orgID)
 		if err != nil {
 			http.Error(w, "failed to fetch teams", http.StatusInternalServerError)
 			return
 		}
-		defer teamRows.Close()
 
-		teamIdx := 0
-		for teamRows.Next() {
-			var team Team
-			if err := teamRows.Scan(&team.ID, &team.Name, &team.Color, &team.Members); err != nil {
-				http.Error(w, "failed to scan team", http.StatusInternalServerError)
-				return
+		for teamIdx, tr := range teamRows {
+			team := Team{
+				ID:      tr.ID,
+				Name:    tr.Name,
+				Color:   tr.Color,
+				Members: tr.Members,
 			}
 
 			// Apply hardcoded values
@@ -106,7 +147,6 @@ func Teams(pool *pgxpool.Pool) http.HandlerFunc {
 			}
 
 			resp.Teams = append(resp.Teams, team)
-			teamIdx++
 		}
 
 		// Heatmap: 6×10 matrix from screens1.jsx:249-256

--- a/server/internal/handler/teams_test.go
+++ b/server/internal/handler/teams_test.go
@@ -1,0 +1,157 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type mockTeamsRepo struct {
+	teams    []TeamRow
+	err      error
+	gotOrgID string
+}
+
+func (m *mockTeamsRepo) ListTeams(_ context.Context, orgID string) ([]TeamRow, error) {
+	m.gotOrgID = orgID
+	return m.teams, m.err
+}
+
+func TestTeamsHappyPath(t *testing.T) {
+	mock := &mockTeamsRepo{
+		teams: []TeamRow{
+			{ID: "t1", Name: "Engineering", Color: "#3b82f6", Members: 48},
+			{ID: "t2", Name: "Design", Color: "#8b5cf6", Members: 22},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/teams", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Teams(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp TeamsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.Teams) != 2 {
+		t.Fatalf("expected 2 teams, got %d", len(resp.Teams))
+	}
+	if resp.Teams[0].Name != "Engineering" {
+		t.Errorf("expected name Engineering, got %s", resp.Teams[0].Name)
+	}
+	if resp.Teams[0].ID != "t1" {
+		t.Errorf("expected ID t1, got %s", resp.Teams[0].ID)
+	}
+	if resp.Teams[0].Spend != 28420 {
+		t.Errorf("expected spend 28420, got %f", resp.Teams[0].Spend)
+	}
+	if len(resp.Heatmap) != 6 {
+		t.Errorf("expected 6 heatmap rows, got %d", len(resp.Heatmap))
+	}
+	if len(resp.CostVsOutput) != 2 {
+		t.Errorf("expected 2 cost_vs_output entries, got %d", len(resp.CostVsOutput))
+	}
+}
+
+func TestTeamsEmptyResult(t *testing.T) {
+	mock := &mockTeamsRepo{
+		teams: []TeamRow{},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/teams", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Teams(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp TeamsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Teams == nil {
+		t.Fatal("expected non-nil teams array, got null")
+	}
+	if len(resp.Teams) != 0 {
+		t.Errorf("expected 0 teams, got %d", len(resp.Teams))
+	}
+	if len(resp.Heatmap) != 6 {
+		t.Errorf("expected 6 heatmap rows even with no teams, got %d", len(resp.Heatmap))
+	}
+	if len(resp.CostVsOutput) != 0 {
+		t.Errorf("expected 0 cost_vs_output entries, got %d", len(resp.CostVsOutput))
+	}
+}
+
+func TestTeamsRepoError(t *testing.T) {
+	mock := &mockTeamsRepo{
+		err: errors.New("connection refused"),
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/teams", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Teams(mock)(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "failed to fetch teams") {
+		t.Errorf("expected body to contain 'failed to fetch teams', got %q", body)
+	}
+}
+
+func TestTeamsUnauthorized(t *testing.T) {
+	mock := &mockTeamsRepo{}
+
+	req := httptest.NewRequest("GET", "/api/v1/teams", nil)
+	w := httptest.NewRecorder()
+
+	Teams(mock)(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestTeamsNilRepo(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/teams", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Teams(nil)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp TeamsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Teams == nil {
+		t.Fatal("expected non-nil teams array, got null")
+	}
+	if len(resp.Teams) != 0 {
+		t.Errorf("expected 0 teams, got %d", len(resp.Teams))
+	}
+}


### PR DESCRIPTION
## Summary

Pillar 2 of [#34](https://github.com/usagely/usagely/issues/34) — medium handlers. Three more repo interfaces. \`forecast.go\` has multiple stitched queries; the interface has one method per logical query so each branch is independently mockable.

> Stacked on #40.

## What changed

| Handler | Interface | Test file |
|---|---|---|
| \`anomalies.go\` | \`AnomaliesRepo\` | [\`anomalies_test.go\`](server/internal/handler/anomalies_test.go) |
| \`forecast.go\` | \`ForecastRepo\` | [\`forecast_test.go\`](server/internal/handler/forecast_test.go) |
| \`teams.go\` | \`TeamsRepo\` | [\`teams_test.go\`](server/internal/handler/teams_test.go) |

Tests cover happy path, empty, repo error, unauthorized, nil repo. Hand-written mocks.

[\`server/cmd/api/main.go\`](server/cmd/api/main.go) — three-line wiring change.

No behaviour change. Tenancy lint stays green.

## Closes

Three more checkboxes under #34 Pillar 2.