### PR TITLE
test(handler): cover people (with cross-tenant) and health.Ready

### DIFF
--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -41,7 +41,7 @@ func main() {
 	r.Use(middleware.Recovery)
 	r.Use(middleware.CORS(cfg.CORSOrigin))
 	r.Get("/healthz", handler.Health)
-	r.Get("/healthz/ready", handler.Ready(pool))
+	r.Get("/healthz/ready", handler.Ready(handler.NewPgxPingable(pool)))
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(authMiddleware.Handler)
@@ -53,8 +53,9 @@ func main() {
 		r.Get("/settings", handler.Settings(handler.NewPgxSettingsRepo(pool)))
 		r.Get("/tools", handler.Tools(handler.NewPgxToolsRepo(pool)))
 		r.Get("/models", handler.Models(handler.NewPgxModelsRepo(pool)))
-		r.Get("/people", handler.People(pool))
-		r.Get("/people/{email}", handler.Profile(pool))
+		peopleRepo := handler.NewPgxPeopleRepo(pool)
+		r.Get("/people", handler.People(peopleRepo))
+		r.Get("/people/{email}", handler.Profile(peopleRepo))
 		r.Get("/recommendations", handler.Recommendations(handler.NewPgxRecommendationsRepo(pool)))
 		r.Get("/shadow", handler.Shadow(handler.NewPgxShadowRepo(pool)))
 		r.Get("/approvals", handler.Approvals(handler.NewPgxApprovalsRepo(pool)))

--- a/server/internal/handler/health.go
+++ b/server/internal/handler/health.go
@@ -19,6 +19,27 @@ type ReadyResponse struct {
 	Error  string `json:"error,omitempty"`
 }
 
+// Pingable abstracts the database ping for testing.
+type Pingable interface {
+	Ping(ctx context.Context) error
+}
+
+type pgxPingable struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgxPingable returns a Pingable backed by pgxpool, or nil when pool is nil.
+func NewPgxPingable(pool *pgxpool.Pool) Pingable {
+	if pool == nil {
+		return nil
+	}
+	return &pgxPingable{pool: pool}
+}
+
+func (p *pgxPingable) Ping(ctx context.Context) error {
+	return p.pool.Ping(ctx)
+}
+
 func Health(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -28,14 +49,23 @@ func Health(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func Ready(pool *pgxpool.Pool) http.HandlerFunc {
+func Ready(p Pingable) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+
+		if p == nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(ReadyResponse{
+				Status: "not ready",
+				Error:  "database not configured",
+			})
+			return
+		}
 
 		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 		defer cancel()
 
-		if err := pool.Ping(ctx); err != nil {
+		if err := p.Ping(ctx); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			json.NewEncoder(w).Encode(ReadyResponse{
 				Status: "not ready",

--- a/server/internal/handler/health_test.go
+++ b/server/internal/handler/health_test.go
@@ -3,13 +3,11 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
+	"strings"
 	"testing"
-	"time"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestHealth(t *testing.T) {
@@ -36,29 +34,21 @@ func TestHealth(t *testing.T) {
 	}
 }
 
-// TestReady covers the happy path only. The failure path (503 when the DB is
-// unreachable) is not unit-tested because pgxpool.Pool is a concrete type that
-// requires a live Postgres connection; there is no test-double infrastructure
-// in this project yet.
-func TestReady(t *testing.T) {
-	dsn := os.Getenv("DATABASE_URL")
-	if dsn == "" {
-		t.Skip("DATABASE_URL not set — skipping readiness probe integration test")
-	}
+type mockPingable struct {
+	err error
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+func (m *mockPingable) Ping(_ context.Context) error {
+	return m.err
+}
 
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("failed to create pool: %v", err)
-	}
-	defer pool.Close()
+func TestReadyOK(t *testing.T) {
+	mock := &mockPingable{}
 
 	req := httptest.NewRequest("GET", "/healthz/ready", nil)
 	w := httptest.NewRecorder()
 
-	Ready(pool)(w, req)
+	Ready(mock)(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", w.Code)
@@ -71,5 +61,57 @@ func TestReady(t *testing.T) {
 
 	if resp.Status != "ready" {
 		t.Errorf("expected status 'ready', got '%s'", resp.Status)
+	}
+}
+
+func TestReadyError(t *testing.T) {
+	mock := &mockPingable{err: errors.New("connection refused")}
+
+	req := httptest.NewRequest("GET", "/healthz/ready", nil)
+	w := httptest.NewRecorder()
+
+	Ready(mock)(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", w.Code)
+	}
+
+	var resp ReadyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Status != "not ready" {
+		t.Errorf("expected status 'not ready', got '%s'", resp.Status)
+	}
+	if !strings.Contains(resp.Error, "connection refused") {
+		t.Errorf("expected error to contain 'connection refused', got '%s'", resp.Error)
+	}
+}
+
+func TestReadyNilPingable(t *testing.T) {
+	req := httptest.NewRequest("GET", "/healthz/ready", nil)
+	w := httptest.NewRecorder()
+
+	Ready(nil)(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", w.Code)
+	}
+
+	var resp ReadyResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Status != "not ready" {
+		t.Errorf("expected status 'not ready', got '%s'", resp.Status)
+	}
+}
+
+func TestNewPgxPingableNil(t *testing.T) {
+	p := NewPgxPingable(nil)
+	if p != nil {
+		t.Error("expected nil pingable when pool is nil")
 	}
 }

--- a/server/internal/handler/people.go
+++ b/server/internal/handler/people.go
@@ -84,75 +84,125 @@ type ProfileResponse struct {
 	Sessions      []Session       `json:"sessions"`
 }
 
-// People returns a handler that lists all users with optional team filter
-func People(pool *pgxpool.Pool) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-		defer cancel()
+// PeopleRepo abstracts people and profile queries for testing.
+type PeopleRepo interface {
+	ListPeople(ctx context.Context, orgID string, team string) ([]User, error)
+	GetProfile(ctx context.Context, orgID string, email string) (*User, error)
+}
 
+type pgxPeopleRepo struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgxPeopleRepo returns a PeopleRepo backed by pgxpool, or nil when pool is nil.
+func NewPgxPeopleRepo(pool *pgxpool.Pool) PeopleRepo {
+	if pool == nil {
+		return nil
+	}
+	return &pgxPeopleRepo{pool: pool}
+}
+
+func (r *pgxPeopleRepo) ListPeople(ctx context.Context, orgID string, team string) ([]User, error) {
+	query := `
+		SELECT u.id, u.name, u.email, t.name, u.role,
+			   COALESCE(uu.tokens, 0), COALESCE(uu.cost_usd, 0),
+			   COALESCE(uu.prs_merged, 0), COALESCE(uu.top_tool, '')
+		FROM users u
+		LEFT JOIN teams t ON u.team_id = t.id
+		LEFT JOIN user_usage uu ON uu.user_id = u.id
+		WHERE u.org_id = $1
+	`
+	args := []interface{}{orgID}
+
+	if team != "" && team != "All" {
+		query += ` AND t.name = $2`
+		args = append(args, team)
+	}
+
+	query += ` ORDER BY u.name ASC`
+
+	// tenancy:ok query is built above with WHERE u.org_id = $1
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []User
+	for rows.Next() {
+		var u User
+		var teamName *string
+		if err := rows.Scan(&u.ID, &u.Name, &u.Email, &teamName, &u.Role,
+			&u.Tokens, &u.Cost, &u.PRs, &u.TopTool); err != nil {
+			return nil, err
+		}
+		if teamName != nil {
+			u.Team = *teamName
+		}
+		users = append(users, u)
+	}
+
+	return users, nil
+}
+
+func (r *pgxPeopleRepo) GetProfile(ctx context.Context, orgID string, email string) (*User, error) {
+	row := r.pool.QueryRow(ctx, `
+		SELECT u.id, u.name, u.email, t.name, u.role,
+			   COALESCE(uu.tokens, 0), COALESCE(uu.cost_usd, 0),
+			   COALESCE(uu.prs_merged, 0), COALESCE(uu.top_tool, '')
+		FROM users u
+		LEFT JOIN teams t ON u.team_id = t.id
+		LEFT JOIN user_usage uu ON uu.user_id = u.id
+		WHERE u.org_id = $1 AND u.email = $2
+	`, orgID, email)
+
+	var u User
+	var teamName *string
+	if err := row.Scan(&u.ID, &u.Name, &u.Email, &teamName, &u.Role,
+		&u.Tokens, &u.Cost, &u.PRs, &u.TopTool); err != nil {
+		return nil, err
+	}
+	if teamName != nil {
+		u.Team = *teamName
+	}
+
+	return &u, nil
+}
+
+// People returns a handler that lists all users with optional team filter
+func People(repo PeopleRepo) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		resp := &PeopleResponse{
 			Users: []User{},
 		}
 
-		// If no pool, return empty response
-		if pool == nil {
+		if repo == nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
-		// Get org_id from context (set by auth middleware)
 		orgID, ok := r.Context().Value("org_id").(string)
 		if !ok || orgID == "" {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		// Get team filter from query params
 		team := r.URL.Query().Get("team")
 
-		// Build query
-		query := `
-			SELECT u.id, u.name, u.email, t.name, u.role,
-				   COALESCE(uu.tokens, 0), COALESCE(uu.cost_usd, 0),
-				   COALESCE(uu.prs_merged, 0), COALESCE(uu.top_tool, '')
-			FROM users u
-			LEFT JOIN teams t ON u.team_id = t.id
-			LEFT JOIN user_usage uu ON uu.user_id = u.id
-			WHERE u.org_id = $1
-		`
-		args := []interface{}{orgID}
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
 
-		if team != "" && team != "All" {
-			query += ` AND t.name = $2`
-			args = append(args, team)
-		}
-
-		query += ` ORDER BY u.name ASC`
-
-		// tenancy:ok query is built above with WHERE u.org_id = $1
-		rows, err := pool.Query(ctx, query, args...)
+		users, err := repo.ListPeople(ctx, orgID, team)
 		if err != nil {
 			log.Printf("people: query error: %v", err)
 			http.Error(w, "failed to fetch users", http.StatusInternalServerError)
 			return
 		}
-		defer rows.Close()
 
-		for rows.Next() {
-			var u User
-			var teamName *string
-			if err := rows.Scan(&u.ID, &u.Name, &u.Email, &teamName, &u.Role,
-				&u.Tokens, &u.Cost, &u.PRs, &u.TopTool); err != nil {
-				log.Printf("people: scan error: %v", err)
-				http.Error(w, "failed to scan user", http.StatusInternalServerError)
-				return
-			}
-			if teamName != nil {
-				u.Team = *teamName
-			}
-			resp.Users = append(resp.Users, u)
+		if users != nil {
+			resp.Users = users
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -162,11 +212,8 @@ func People(pool *pgxpool.Pool) http.HandlerFunc {
 }
 
 // Profile returns a handler that fetches a user's full profile by email
-func Profile(pool *pgxpool.Pool) http.HandlerFunc {
+func Profile(repo PeopleRepo) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
-		defer cancel()
-
 		email := r.PathValue("email")
 		if email == "" {
 			http.Error(w, "email required", http.StatusBadRequest)
@@ -185,41 +232,37 @@ func Profile(pool *pgxpool.Pool) http.HandlerFunc {
 			Sessions:      []Session{},
 		}
 
-		// If no pool, return empty response
-		if pool == nil {
+		if repo == nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(resp)
 			return
 		}
 
-		// Get org_id from context
 		orgID, ok := r.Context().Value("org_id").(string)
 		if !ok || orgID == "" {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		// Fetch user by email
-		row := pool.QueryRow(ctx, `
-			SELECT u.id, u.name, u.email, t.name, u.role,
-				   COALESCE(uu.tokens, 0), COALESCE(uu.cost_usd, 0),
-				   COALESCE(uu.prs_merged, 0), COALESCE(uu.top_tool, '')
-			FROM users u
-			LEFT JOIN teams t ON u.team_id = t.id
-			LEFT JOIN user_usage uu ON uu.user_id = u.id
-			WHERE u.org_id = $1 AND u.email = $2
-		`, orgID, email)
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
 
-		var teamName *string
-		if err := row.Scan(&resp.ID, &resp.Name, &resp.Email, &teamName, &resp.Role,
-			&resp.Tokens, &resp.Cost, &resp.PRs, &resp.TopTool); err != nil {
+		u, err := repo.GetProfile(ctx, orgID, email)
+		if err != nil {
 			http.Error(w, "user not found", http.StatusNotFound)
 			return
 		}
-		if teamName != nil {
-			resp.Team = *teamName
-		}
+
+		resp.ID = u.ID
+		resp.Name = u.Name
+		resp.Email = u.Email
+		resp.Team = u.Team
+		resp.Role = u.Role
+		resp.Tokens = u.Tokens
+		resp.Cost = u.Cost
+		resp.PRs = u.PRs
+		resp.TopTool = u.TopTool
 
 		// Generate daily activity (30 days of synthetic data)
 		now := time.Now()

--- a/server/internal/handler/people_test.go
+++ b/server/internal/handler/people_test.go
@@ -1,0 +1,372 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type mockPeopleRepo struct {
+	users      []User
+	usersErr   error
+	profile    *User
+	profileErr error
+	gotOrgID   string
+	gotTeam    string
+	gotEmail   string
+}
+
+func (m *mockPeopleRepo) ListPeople(_ context.Context, orgID string, team string) ([]User, error) {
+	m.gotOrgID = orgID
+	m.gotTeam = team
+	return m.users, m.usersErr
+}
+
+func (m *mockPeopleRepo) GetProfile(_ context.Context, orgID string, email string) (*User, error) {
+	m.gotOrgID = orgID
+	m.gotEmail = email
+	return m.profile, m.profileErr
+}
+
+// ---------------------------------------------------------------------------
+// People handler
+// ---------------------------------------------------------------------------
+
+func TestPeopleHappyPath(t *testing.T) {
+	mock := &mockPeopleRepo{
+		users: []User{
+			{ID: "u1", Name: "Alice", Email: "alice@acme.co", Team: "Engineering", Role: "engineer", Tokens: 1000, Cost: 50.0, PRs: 10, TopTool: "Cursor"},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/people", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	People(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp PeopleResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.Users) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(resp.Users))
+	}
+	if resp.Users[0].Name != "Alice" {
+		t.Errorf("expected name Alice, got %s", resp.Users[0].Name)
+	}
+	if resp.Users[0].ID != "u1" {
+		t.Errorf("expected ID u1, got %s", resp.Users[0].ID)
+	}
+	if mock.gotOrgID != "test-org" {
+		t.Errorf("expected org_id test-org, got %s", mock.gotOrgID)
+	}
+}
+
+func TestPeopleEmptyResult(t *testing.T) {
+	mock := &mockPeopleRepo{
+		users: []User{},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/people", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	People(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp PeopleResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Users == nil {
+		t.Fatal("expected non-nil users array, got null")
+	}
+	if len(resp.Users) != 0 {
+		t.Errorf("expected 0 users, got %d", len(resp.Users))
+	}
+}
+
+func TestPeopleRepoError(t *testing.T) {
+	mock := &mockPeopleRepo{
+		usersErr: errors.New("connection refused"),
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/people", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	People(mock)(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "failed to fetch users") {
+		t.Errorf("expected body to contain 'failed to fetch users', got %q", body)
+	}
+}
+
+func TestPeopleUnauthorized(t *testing.T) {
+	mock := &mockPeopleRepo{}
+
+	req := httptest.NewRequest("GET", "/api/v1/people", nil)
+	w := httptest.NewRecorder()
+
+	People(mock)(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestPeopleNilRepo(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/people", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	People(nil)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp PeopleResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Users == nil {
+		t.Fatal("expected non-nil users array, got null")
+	}
+	if len(resp.Users) != 0 {
+		t.Errorf("expected 0 users, got %d", len(resp.Users))
+	}
+}
+
+func TestPeopleCrossTenant(t *testing.T) {
+	mock := &mockPeopleRepo{
+		users: []User{
+			{ID: "u1", Name: "Alice", Email: "alice@acme.co", Team: "Engineering"},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/people", nil)
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "org-A"))
+	w := httptest.NewRecorder()
+
+	People(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	if mock.gotOrgID != "org-A" {
+		t.Errorf("expected repo called with org_id 'org-A', got %q", mock.gotOrgID)
+	}
+
+	var resp PeopleResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.Users) != 1 {
+		t.Fatalf("expected 1 user from mock, got %d", len(resp.Users))
+	}
+	if resp.Users[0].Name != "Alice" {
+		t.Errorf("expected name Alice, got %s", resp.Users[0].Name)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Profile handler
+// ---------------------------------------------------------------------------
+
+func TestProfileHappyPath(t *testing.T) {
+	mock := &mockPeopleRepo{
+		profile: &User{ID: "u1", Name: "Alice", Email: "alice@acme.co", Team: "Engineering", Role: "engineer", Tokens: 1000, Cost: 50.0, PRs: 10, TopTool: "Cursor"},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/people/alice@acme.co", nil)
+	req.SetPathValue("email", "alice@acme.co")
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Profile(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ProfileResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Name != "Alice" {
+		t.Errorf("expected name Alice, got %s", resp.Name)
+	}
+	if resp.Email != "alice@acme.co" {
+		t.Errorf("expected email alice@acme.co, got %s", resp.Email)
+	}
+	if resp.Team != "Engineering" {
+		t.Errorf("expected team Engineering, got %s", resp.Team)
+	}
+	if len(resp.DailyActivity) != 30 {
+		t.Errorf("expected 30 daily activity entries, got %d", len(resp.DailyActivity))
+	}
+	if len(resp.HourlyPattern) != 7 {
+		t.Errorf("expected 7 hourly pattern entries, got %d", len(resp.HourlyPattern))
+	}
+	if len(resp.Models) != 4 {
+		t.Errorf("expected 4 models, got %d", len(resp.Models))
+	}
+	if len(resp.Tools) != 6 {
+		t.Errorf("expected 6 tools, got %d", len(resp.Tools))
+	}
+	if len(resp.Sessions) != 6 {
+		t.Errorf("expected 6 sessions, got %d", len(resp.Sessions))
+	}
+	if mock.gotOrgID != "test-org" {
+		t.Errorf("expected org_id test-org, got %s", mock.gotOrgID)
+	}
+	if mock.gotEmail != "alice@acme.co" {
+		t.Errorf("expected email alice@acme.co, got %s", mock.gotEmail)
+	}
+}
+
+func TestProfileEmptyEmail(t *testing.T) {
+	mock := &mockPeopleRepo{}
+
+	req := httptest.NewRequest("GET", "/api/v1/people/", nil)
+	w := httptest.NewRecorder()
+
+	Profile(mock)(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "email required") {
+		t.Errorf("expected body to contain 'email required', got %q", body)
+	}
+}
+
+func TestProfileRepoError(t *testing.T) {
+	mock := &mockPeopleRepo{
+		profileErr: errors.New("not found"),
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/people/alice@acme.co", nil)
+	req.SetPathValue("email", "alice@acme.co")
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Profile(mock)(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "user not found") {
+		t.Errorf("expected body to contain 'user not found', got %q", body)
+	}
+}
+
+func TestProfileUnauthorized(t *testing.T) {
+	mock := &mockPeopleRepo{}
+
+	req := httptest.NewRequest("GET", "/api/v1/people/alice@acme.co", nil)
+	req.SetPathValue("email", "alice@acme.co")
+	w := httptest.NewRecorder()
+
+	Profile(mock)(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestProfileNilRepo(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/people/alice@acme.co", nil)
+	req.SetPathValue("email", "alice@acme.co")
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "test-org"))
+	w := httptest.NewRecorder()
+
+	Profile(nil)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp ProfileResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.DailyActivity == nil {
+		t.Fatal("expected non-nil daily_activity, got nil")
+	}
+	if resp.Models == nil {
+		t.Fatal("expected non-nil models, got nil")
+	}
+	if resp.Tools == nil {
+		t.Fatal("expected non-nil tools, got nil")
+	}
+	if resp.Sessions == nil {
+		t.Fatal("expected non-nil sessions, got nil")
+	}
+}
+
+func TestProfileCrossTenant(t *testing.T) {
+	mock := &mockPeopleRepo{
+		profile: &User{ID: "u1", Name: "Alice", Email: "alice@acme.co", Team: "Engineering"},
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/people/alice@acme.co", nil)
+	req.SetPathValue("email", "alice@acme.co")
+	req = req.WithContext(context.WithValue(req.Context(), "org_id", "org-A"))
+	w := httptest.NewRecorder()
+
+	Profile(mock)(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	if mock.gotOrgID != "org-A" {
+		t.Errorf("expected repo called with org_id 'org-A', got %q", mock.gotOrgID)
+	}
+
+	var resp ProfileResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Name != "Alice" {
+		t.Errorf("expected name Alice, got %s", resp.Name)
+	}
+}
+
+func TestNewPgxPeopleRepoNil(t *testing.T) {
+	repo := NewPgxPeopleRepo(nil)
+	if repo != nil {
+		t.Error("expected nil repo when pool is nil")
+	}
+}


### PR DESCRIPTION
## Summary

Pillar 2 final handler batch + the \`Ready\` endpoint coverage callout from [#34](https://github.com/usagely/usagely/issues/34). \`people.go\` is the largest handler file (10 KB, two exported handlers \`People\` and \`Profile\`); \`health.Ready\` had a \`t.Skip\` from #2 that this PR removes once the seam exists.

> Stacked on #42.

## What changed

### people.go

- New \`PeopleRepo\` interface (one method per logical query both handlers issue).
- \`pgxPeopleRepo\` adapter preserving every \`// tenancy:ok\` and every \`WHERE org_id = \$1\` (the dynamic-SQL path noted in #8 still annotates correctly).
- Both \`People\` and \`Profile\` handlers take \`PeopleRepo\`. Single repo instance shared across both routes in [\`server/cmd/api/main.go\`](server/cmd/api/main.go).
- New [\`people_test.go\`](server/internal/handler/people_test.go) — 13 tests across both handlers covering happy path, empty, repo error, unauthorized, nil repo, **plus the cross-tenant assertion** (mock records the orgID it was called with; test verifies \`gotOrgID == \"org-A\"\` was forwarded by the handler).

### health.go

- New \`Pingable\` interface (\`Ping(ctx) error\`).
- \`pgxPingable\` adapter; \`Ready\` now takes \`Pingable\` instead of \`*pgxpool.Pool\`.
- [\`health_test.go\`](server/internal/handler/health_test.go) — \`t.Skip\` removed; new \`TestReadyOK\`, \`TestReadyError\`, \`TestReadyNilPingable\`, \`TestNewPgxPingableNil\`. Existing \`Health\` tests untouched.

No behaviour change. Tenancy lint stays green.

## Closes

\`people.go\` (both handlers) + \`health.Ready\` checkboxes under #34 Pillar 2. After this PR all handler files have a corresponding \`*_test.go\`.